### PR TITLE
Fix project location for msgbus

### DIFF
--- a/github_data_collector/src/data/issue_comment/alibaba_BeeHive.txt
+++ b/github_data_collector/src/data/issue_comment/alibaba_BeeHive.txt
@@ -24,7 +24,7 @@ http://liumh.com/2018/08/18/ios-attribute-section/#section
 建议在`BHServiceManager.h` 中把获取类名的方法`- (Class)serviceImplClass:(Protocol *)service;`也给暴露出来，因为有的protocol可能有类方法，在调用类方法时候时可能还没必要创建实体对象。
 
 ![image](https://user-images.githubusercontent.com/5189595/57685246-17d5a880-766a-11e9-96f4-84b21fa82f73.png)
-There are lots of "message brokers" out there; but none quite as simple to use and deploy as [msgbus](https://github.com/prologic/msgbus). To that end (*time permitting*) I will contribute such a bee which will afford you great flexibility in:
+There are lots of "message brokers" out there; but none quite as simple to use and deploy as [msgbus](https://git.mills.io/prologic/msgbus). To that end (*time permitting*) I will contribute such a bee which will afford you great flexibility in:
 
 * Receiving generic "webhook" style messages from msgbus as a source of events
 * Publish messages to msgbus from other bees as a general purpose way to externally integrate with other msgbus consumers.


### PR DESCRIPTION
Project has moved to [git.mills.io/prologic/bitcask](https://git.mills.io/prologic/bitcask).

For details on why see: https://github.com/prologic

Thank you! 🙇